### PR TITLE
Feature/make gradle test task possible and run tests after build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,5 +21,7 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Run test with Gradle
+      run: ./gradlew test
     - name: Upload codecov report
       run: bash <(curl -s https://codecov.io/bash)

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,9 @@ buildscript {
 }
 
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "$detekt_version"
-    id "org.jlleitschuh.gradle.ktlint" version "$ktlint_version"
-    id "org.jetbrains.dokka" version "$dokka_version"
+    id "io.gitlab.arturbosch.detekt" version "1.11.0-RC1"
+    id "org.jlleitschuh.gradle.ktlint" version "9.3.0"
+    id "org.jetbrains.dokka" version "0.10.1"
     id "jacoco"
 }
 


### PR DESCRIPTION
Nie szły mi test/build z command line i po prostu było szybciej aby hardcodować, obiecuje, że zrobię to poprawnie i poprawię XD https://github.com/gradle/gradle/issues/1697
Wgl bo może ja czegoś do końca nie rozumiem, jak to działa z tymi testami w stylu nie powinniśmy dodać po `build` aby poszedł `test` w celu późniejszego wysłania raportu ?